### PR TITLE
Update description PropertyCompositionToAssociation

### DIFF
--- a/model-transformations/EuropeanLegislationIdentifier.md
+++ b/model-transformations/EuropeanLegislationIdentifier.md
@@ -1,0 +1,113 @@
+## European Legislation Identifier
+
+<table>
+<tr>
+<td>Category</td>
+<td>Alternative structures for specific types or type hierarchies</td>
+</tr>
+<tr>
+<td>Description</td>
+<td>
+<p>This model transformation replaces the LegislationCitation class from the Base Types 2 application schema by a class having the semantics of the LegalResource class as defined in the [European Legislation Identifier ontology](https://publications.europa.eu/en/web/eu-vocabularies/model/-/resource/dataset/eli).</p>
+<p>This model transformation is intended to be used together with (TODO link to "Restriction of property encoding options to only by-reference") and followed by an encoding defined by the [European Legislation Identifier specification](https://publications.europa.eu/en/web/eu-vocabularies/model/-/resource/dataset/eli).</p>
+</td>
+</tr>
+<tr>
+<td>UML Model</td>
+<td>TODO (no official UML model for ELI exists currently)</td>
+</tr>
+<tr>
+<td>Original instance in default encoding:</td>
+<td>
+
+```xml
+<base2:LegislationCitation>
+  <base2:name>Bekendtgørelse af lov om skove</base2:name>
+  <base2:shortName>LBK nr 315 af 28/03/2019</base2:shortName>
+  <base2:date>
+	<gmd:CI_Date>
+	  <gmd:date>
+		<gco:Date>2019-03-30</gco:Date>
+	  </gmd:date>
+	  <gmd:dateType>
+		<gmd:CI_DateTypeCode
+		  codeListValue="publication"
+		  codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" />
+	  </gmd:dateType>
+	</gmd:CI_Date>
+  </base2:date>
+  <base2:link>http://www.retsinformation.dk/eli/lta/2019/315/dan/pdf</base2:link>
+  <base2:level
+	xlink:href="http://inspire.ec.europa.eu/codelist/LegislationLevelValue/national"
+	xlink:title="national" />
+</base2:LegislationCitation>
+```
+
+</td>
+</tr>
+<tr>
+<td>Transformed instance in default encoding:</td>
+<td>
+<p>Not applicable: this model transformation must be used together with another encoding rule including a conversion rule that uses an existing schema for encoding the LegalResource class.</p>
+</td>
+</tr>
+<tr>
+<td>Transformed instance in RDF encoding:</td>
+<td>
+
+```xml
+<eli:LegalResource rdf:about="https://www.retsinformation.dk/eli/lta/2019/315">
+    <eli:date_publication rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-03-30</eli:date_publication>
+    <eli:is_realized_by rdf:resource="http://example.dk/path/to/specific/law/dan" />
+</eli:LegalResource>
+<eli:LegalExpression rdf:about="https://www.retsinformation.dk/eli/lta/2019/315/dan">
+    <eli:realizes rdf:resource="https://www.retsinformation.dk/eli/lta/2019/315" />
+    <eli:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bekendtgørelse af lov om skove</eli:title>
+    <eli:title_short rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LBK nr 315 af 28/03/2019</eli:title_short>
+</eli:LegalExpression>
+<!-- TODO level? eli:AdministrativeArea?-->
+<eli:Format rdf:about="http://www.retsinformation.dk/eli/lta/2019/315/dan/pdf">
+    <eli:embodies rdf:resource="http://www.retsinformation.dk/eli/lta/2019/315/dan" />
+</eli:Format>
+```
+
+</td>
+</tr>
+<tr>
+<td>Model transformation rule: </td>
+<td>
+    <p>Parameters:</p>
+    <ul>
+        <li>`separator`: The character to use to separate the original property name from the type name of the components.</li>
+    </ul>
+    <p>...</p>
+</td>
+</tr>
+<tr>
+<td>Instance transformation rule:</td>
+<td><p>Parameters:</p>
+    <ul>
+        <li>`valueProperty`: The name of the property from which to take the value to be copied to the transformed instance.</li>
+    </ul>
+    <p>...</p>
+    </td>
+</tr>
+<tr>
+<td>Solves usability issues:</td>
+<td>...</td>
+</tr>
+<tr>
+<td>Known usability issues:</td>
+<td>...</td>
+</tr>
+<tr>
+<td>INSPIRE Compliance:</td>
+<td>...</td>
+</tr>
+<tr>
+<td>Examples of this encoding rule:</td>
+<td>TODO List issues in 2017.2 repo that have applied this pattern or very similar ones.</td>
+</tr>
+</table>
+
+Notes: No notes.

--- a/model-transformations/PropertyCompositionToAssociation.md
+++ b/model-transformations/PropertyCompositionToAssociation.md
@@ -7,9 +7,7 @@
 </tr>
 <tr>
 <td>Description</td>
-<td><p>Information regarding resources such as legal documents can be stored in an external register or non-INSPIRE online application, possibly using other standardised encodings.  Such information should not be duplicated in the INSPIRE model if possible. Thus, the information should be referred to from a GML application schema "by reference".</p>
-
-<p>It gives a lot of work for data providers when they have to document a lot of metadata regarding e.g. laws, documents, authorities, etc. that they are not responsible for, and when this information is already online somewhere else this is redundant work. Therefore, properties referring to laws, documents, authorities and other online resources not typically belonging to the geographic information domain should be implemented by reference, and it should be recognised that their values are not necessarily encoded in a spatial data format.</p>
+<td><p>Information regarding certain types of resources is typically accessible through an external register or non-INSPIRE online application. Those resources should be referred to "by reference".</p>
 </td>
 </tr>
 <tr>
@@ -27,20 +25,20 @@
   <am:legalBasis>
     <base2:LegislationCitation>
       <base2:name>Bekendtgørelse af lov om skove</base2:name>
-      <base2:shortName>LBK nr 122 af 26/01/2017</base2:shortName>
+      <base2:shortName>LBK nr 315 af 28/03/2019</base2:shortName>
       <base2:date>
         <gmd:CI_Date>
           <gmd:date>
-            <gco:Date>2017-01-26</gco:Date>
+            <gco:Date>2019-03-30</gco:Date>
           </gmd:date>
           <gmd:dateType>
             <gmd:CI_DateTypeCode
-              codeListValue="creation"
+              codeListValue="publication"
               codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" />
           </gmd:dateType>
         </gmd:CI_Date>
       </base2:date>
-      <base2:link>http://www.retsinformation.dk/eli/lta/2017/122</base2:link>
+      <base2:link>http://www.retsinformation.dk/eli/lta/2019/315/dan/pdf</base2:link>
       <base2:level
         xlink:href="http://inspire.ec.europa.eu/codelist/LegislationLevelValue/national"
         xlink:title="national" />
@@ -56,7 +54,7 @@
 <am:ManagementRestrictionOrRegulationZone>
   <!-- ... -->
   <am:legalBasis
-    xlink:href="http://www.retsinformation.dk/eli/lta/2017/122"
+    xlink:href="http://example.dk/path/to/specific/law/resource"
     xlink:title="Bekendtgørelse af lov om skove" />
   <!-- ... -->
 </am:ManagementRestrictionOrRegulationZone>
@@ -70,24 +68,24 @@
 <am:ManagementRestrictionOrRegulationZone>
   <!-- ... -->
   <am:legalBasis
-    xlink:href="http://www.retsinformation.dk/eli/lta/2017/122"
+    xlink:href="http://example.dk/path/to/specific/law/resource"
     xlink:title="Bekendtgørelse af lov om skove">
     <base2:LegislationCitation>
       <base2:name>Bekendtgørelse af lov om skove</base2:name>
-      <base2:shortName>LBK nr 122 af 26/01/2017</base2:shortName>
+      <base2:shortName>LBK nr 315 af 28/03/2019</base2:shortName>
       <base2:date>
         <gmd:CI_Date>
           <gmd:date>
-            <gco:Date>2017-01-26</gco:Date>
+            <gco:Date>2019-03-30</gco:Date>
           </gmd:date>
           <gmd:dateType>
             <gmd:CI_DateTypeCode
-              codeListValue="creation"
+              codeListValue="publication"
               codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" />
           </gmd:dateType>
         </gmd:CI_Date>
       </base2:date>
-      <base2:link>http://www.retsinformation.dk/eli/lta/2017/122</base2:link>
+      <base2:link>http://www.retsinformation.dk/eli/lta/2019/315/dan/pdf</base2:link>
       <base2:level
         xlink:href="http://inspire.ec.europa.eu/codelist/LegislationLevelValue/national"
         xlink:title="national" />
@@ -107,7 +105,7 @@
 <ams:ManagementRestrictionOrRegulationZone>
   <!-- ... -->
   <ams:legalBasis
-    xlink:href="http://www.retsinformation.dk/eli/lta/2017/122"
+    xlink:href="http://example.dk/path/to/specific/law/resource"
     xlink:title="Bekendtgørelse af lov om skove"
   />
   <!-- ... -->
@@ -129,8 +127,8 @@
 <tr>
 <td>Instance transformation rule:</td>
 <td><p>Parameters: None</p>
-    <p>It is only possible to convert an instance using the "inline" pattern when the URL is present in the original data or can be added upon transformation from the original data to the INSPIRE data. This URL must be inserted in <code>@xlink:href</code>.</p>
-    <p>A name or title (e.g. "Bekendtgørelse af lov om skove"), or even a full-blown bibliographic reference (e.g. "Bekendtgørelse af lov om skove. 26 januar 2017. LBK nr 122."), if present, may be inserted in <code>@xlink:title</code>.</p>
+    <p>It is only possible to convert an instance using the "inline" pattern when a URL to the related resource is present in the original data or can be added upon transformation from the original data to the INSPIRE data. This URL must be inserted in <code>@xlink:href</code>.</p>
+    <p>A name or title (e.g. "Bekendtgørelse af lov om skove"), or even a full-blown bibliographic reference in the case of objects that are information resources (e.g. "Bekendtgørelse af lov om skove. 28 marts 2019. LBK nr 315."), if present, may be inserted in <code>@xlink:title</code>.</p>
     </td>
 </tr>
 <tr>

--- a/model-transformations/PropertyCompositionToAssociation.md
+++ b/model-transformations/PropertyCompositionToAssociation.md
@@ -129,7 +129,8 @@
 <tr>
 <td>Instance transformation rule:</td>
 <td><p>Parameters: None</p>
-    <p>It is only possible to convert an instance using the "inline" pattern when the URL is present in the original data or can be added upon transformation from the original data to the INSPIRE data. This URL must be inserted in <code>@xlink:href</code>. A name or title, if present, may be inserted in <code>@xlink:title</code>.</p>
+    <p>It is only possible to convert an instance using the "inline" pattern when the URL is present in the original data or can be added upon transformation from the original data to the INSPIRE data. This URL must be inserted in <code>@xlink:href</code>.</p>
+    <p>A name or title (e.g. "Bekendtgørelse af lov om skove"), or even a full-blown bibliographic reference (e.g. "Bekendtgørelse af lov om skove. 26 januar 2017. LBK nr 122."), if present, may be inserted in <code>@xlink:title</code>.</p>
     </td>
 </tr>
 <tr>

--- a/model-transformations/PropertyCompositionToAssociation.md
+++ b/model-transformations/PropertyCompositionToAssociation.md
@@ -1,4 +1,4 @@
-## Property Composition to Association
+## Restriction of property encoding options to only by-reference
 
 <table>
 <tr>
@@ -9,7 +9,7 @@
 <td>Description</td>
 <td><p>Information regarding resources such as legal documents can be stored in an external register or non-INSPIRE online application, possibly using other standardised encodings.  Such information should not be duplicated in the INSPIRE model if possible. Thus, the information should be referred to from a GML application schema "by reference".</p>
 
-<p>It gives a lot of work for data providers when they have to document a lot of metadata regarding e.g. laws, documents, authorities, etc. that they are not responsible for, and when this information is already online somewhere else this is redundant work. Therefore, properties referring to laws, documents, authorities and other online resources not typically belonging to the geographic information domain should be implemented by reference, and it should be recognised that their values are not necessarily encoded in GML.</p>
+<p>It gives a lot of work for data providers when they have to document a lot of metadata regarding e.g. laws, documents, authorities, etc. that they are not responsible for, and when this information is already online somewhere else this is redundant work. Therefore, properties referring to laws, documents, authorities and other online resources not typically belonging to the geographic information domain should be implemented by reference, and it should be recognised that their values are not necessarily encoded in a spatial data format.</p>
 </td>
 </tr>
 <tr>
@@ -19,6 +19,52 @@
 <tr>
 <td>Original instance in default encoding:</td>
 <td>
+<p>Possibility 1: inline</p>
+
+```xml
+<am:ManagementRestrictionOrRegulationZone>
+  <!-- ... -->
+  <am:legalBasis>
+    <base2:LegislationCitation>
+      <base2:name>Bekendtgørelse af lov om skove</base2:name>
+      <base2:shortName>LBK nr 122 af 26/01/2017</base2:shortName>
+      <base2:date>
+        <gmd:CI_Date>
+          <gmd:date>
+            <gco:Date>2017-01-26</gco:Date>
+          </gmd:date>
+          <gmd:dateType>
+            <gmd:CI_DateTypeCode
+              codeListValue="creation"
+              codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" />
+          </gmd:dateType>
+        </gmd:CI_Date>
+      </base2:date>
+      <base2:link>http://www.retsinformation.dk/eli/lta/2017/122</base2:link>
+      <base2:level
+        xlink:href="http://inspire.ec.europa.eu/codelist/LegislationLevelValue/national"
+        xlink:title="national" />
+    </base2:LegislationCitation>
+  </am:legalBasis>
+  <!-- ... -->
+</am:ManagementRestrictionOrRegulationZone>
+```
+
+<p>Possibility 2: by reference</p>
+
+```xml
+<am:ManagementRestrictionOrRegulationZone>
+  <!-- ... -->
+  <am:legalBasis
+    xlink:href="http://www.retsinformation.dk/eli/lta/2017/122"
+    xlink:title="Bekendtgørelse af lov om skove" />
+  <!-- ... -->
+</am:ManagementRestrictionOrRegulationZone>
+```
+
+<p>Possibility 3: by reference and inline. From the GML standard:</p>
+
+<blockquote>If both a link and content are present in an instance of a property element, then the object found by traversing the xlink:href link shall be the normative value of the property. The object included as content shall be used by the data recipient only if the remote instance cannot be resolved; this may be considered to be a "cached" version of the object.</blockquote>
 
 ```xml
 <am:ManagementRestrictionOrRegulationZone>
@@ -42,13 +88,15 @@
         </gmd:CI_Date>
       </base2:date>
       <base2:link>http://www.retsinformation.dk/eli/lta/2017/122</base2:link>
-      <base2:level xlink:href="http://inspire.ec.europa.eu/codelist/LegislationLevelValue/national" xlink:title="national" />
+      <base2:level
+        xlink:href="http://inspire.ec.europa.eu/codelist/LegislationLevelValue/national"
+        xlink:title="national" />
     </base2:LegislationCitation>
   </am:legalBasis>
   <!-- ... -->
 </am:ManagementRestrictionOrRegulationZone>
 ```
-   
+
 </td>
 </tr>
 <tr>
@@ -71,7 +119,7 @@
 <tr>
 <td>Model transformation rule: </td>
 <td>
-    <p>Parameters:</p> 
+    <p>Parameters:</p>
     <ul>
         <li><code>referenceProperty</code>: The name of the property which to change to a reference.</li>
     </ul>
@@ -80,8 +128,8 @@
 </tr>
 <tr>
 <td>Instance transformation rule:</td>
-<td><p>Parameters: None</p> 
-    <p>It is only possible to convert an instance using the "inline" pattern when the URL is present somewhere in the data, which then must be inserted in <code>@xlink:href</code>. A name or title, if present, may be inserted in <code>@xlink:title</code>.</p>
+<td><p>Parameters: None</p>
+    <p>It is only possible to convert an instance using the "inline" pattern when the URL is present in the original data or can be added upon transformation from the original data to the INSPIRE data. This URL must be inserted in <code>@xlink:href</code>. A name or title, if present, may be inserted in <code>@xlink:title</code>.</p>
     </td>
 </tr>
 <tr>
@@ -94,11 +142,11 @@
 </tr>
 <tr>
 <td>INSPIRE Compliance:</td>
-<td>Fully compliant.</td>
+<td>Fully compliant if the referenced resource is stored in an external register or non-INSPIRE online application.</td>
 </tr>
 <tr>
 <td>Examples of this encoding rule:</td>
-<td>TODO List issues in 2017.2 repo that have applied this pattern or very similiar ones.</td>
+<td>TODO List issues in 2017.2 repo that have applied this pattern or very similar ones.</td>
 </tr>
 </table>
 


### PR DESCRIPTION
I think the title is wrong, it is not change from composition of association, it is a change of how the association should be encoded.

Proposal for new title: Restriction of property encoding options to only by-reference

I also added some examples, so all three possibilities for encoding a property to another object are present (by-reference, inline, combination of both).