### PR TITLE
update entries related to bijection

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -1,88 +1,87 @@
 # Glossary for Alternative Encodings
 
-**INSPIRE Alternative Encoding Rule**
+**bijective data transformation**
 
-alternative encoding rule
-alternative encoding
+bijective transformation where the two sets are data structures, consisting of data elements
 
-An encoding rule that is not the INSPIRE default encoding rule and meets all requirements from the INSPIRE Implementing Rules on interoperability of spatial data sets and services.
+NOTE 1 A transformed data structure can be transformed back again into the original data structure if the applied data transformation is bijective.
 
-**INSPIRE Additional Encoding Rule**
+**bijective model transformation**
 
-additional encoding rule
-additional encoding
+bijective transformation where the two sets are models, consisting of model elements
 
-An encoding rule that is not the INSPIRE default encoding rule and does not have to meet all requirements from the Implementing Rule on interoperability of spatial data sets and services.
+NOTE 1 The first data model is also called the source model and the second data model is also called the target model.
 
-NOTE Not all elements from the INSPIRE Generic Conceptual Model might be encoded.
+NOTE 2 A transformed model can be transformed back again into the original model if the applied model transformation is bijective.
 
-**Bijective Transformation**
+**bijective transformation**<br />
+bijective function<br />
+bijection
 
-In mathematics, a bijection, bijective function, or one-to-one correspondence is a function between the elements of two sets where each element of one set is paired with exactly one element of the other set, and each element of the other set is  paired with exactly one element of the first set. There are no unpaired elements. In terms of a transformation, this means that for every source model element, there is a corresponding element in the target model, and the transformation can first be executed in the direction `A > B` and then back `B > A'`, with `A` equal to `A'`.
+function between the elements of two sets where each element of one set is paired with exactly one element of the other set, and each element of the other set is paired with exactly one element of the first set.
 
-[Wikipedia]
+NOTE As a consequence, there are no unpaired elements in the two sets.
 
-**Bijective Model Transformation**
+[Based on Wikipedia]
 
-A Bijective Model Transformation is a model transformation where each model element in the source and target model is paired with exactly one element of the other set, and each element of the other set is  paired with exactly one element of the first set. This means if the model transformation between an original model and the transsformed model is lossless, and the original model can be fully recreated based on the transformed model.
+**code**
 
-**Bijective Data Transformation**
-
-This means if the data transformation between the default encoding and the alternative encoding is bijective, that conversion is lossless, and the original data set using the default encoding can be fully recreated based on the data that was transformed to the Alternative Encoding before.
-
-**Code**
-
-Representation of a label according to a specified scheme
+representation of a label according to a specified scheme
 
 [ISO 19118:2011]
 
-**Conversion rule**
+**conversion rule**
 
-Rule for converting instances in the input data structure to instances in the output data structure
+rule for converting instances in the input data structure to instances in the output data structure
 
 [ISO 19118:2011]
 
-**Data**
+**data**
 
-Reinterpretable representation of information in a formalized manner suitable for communication, interpretation, or processing
+reinterpretable representation of information in a formalized manner suitable for communication, interpretation, or processing
 
 [ISO/IEC 2382-1:1993]
 
-**INSPIRE default encoding rule**
+**encoding process**<br />
+encoding
 
-default encoding rule
-default encoding
-
-encoding rule that is specified in [D2.7, Annex B (normative) Default encoding rule]
-
-NOTE The INSPIRE default encoding rule is the encoding rule specified in ISO 19136 Annex E with the extensions in GML 3.3 together with the additional rules stated in [D2.7, Annex B].
-
-**Encoding process**
-
-Encoding
-
-Conversion of data into a series of codes
+conversion of data into a series of codes
 
 [ISO 19118:2011]
 
-**Encoding rule**
+**encoding rule**<br />
+encoding
 
-Encoding
+identifiable collection of conversion rules that define the encoding for a particular data structure
 
-Identifiable collection of conversion rules that define the encoding for a particular data structure
-
-NOTE The term `Encoding` is used as a synonym for both Encoding Rule and Encoding Process and should therefore not be used in the alternative encoding specifications.
+NOTE The term encoding is used as a synonym for both encoding rule and encoding process and should therefore not be used in the alternative encoding specifications.
 
 [ISO 19118:2011]
 
-**Information**
+**information**
 
 Knowledge concerning objects, such as facts, events, things, processes, or ideas, including concepts, that within a certain context has a particular meaning
 
 [ISO/IEC 2382-1:1993]
 
-**Format**
+**INSPIRE additional encoding rule**<br />
+additional encoding rule<br />
+additional encoding
 
-Language construct that specifies the representation, in character form, of data objects in a record, file, message, storage device, or transmission channel
+encoding rule that is not the INSPIRE default encoding rule and does not have to meet all requirements from the Implementing Rule on interoperability of spatial data sets and services
 
-[ISO 19145:2013; ISO/IEC 2382‑15:1999]
+NOTE Not all elements from the INSPIRE Generic Conceptual Model might be encoded.
+
+**INSPIRE alternative encoding rule**<br />
+alternative encoding rule<br />
+alternative encoding
+
+encoding rule that is not the INSPIRE default encoding rule and meets all requirements from the INSPIRE Implementing Rules on interoperability of spatial data sets and services
+
+**INSPIRE default encoding rule**<br />
+default encoding rule<br />
+default encoding
+
+encoding rule that is specified in [D2.7, Annex B (normative) Default encoding rule]
+
+NOTE The INSPIRE default encoding rule is the encoding rule specified in ISO 19136 Annex E with the extensions in GML 3.3 together with the additional rules stated in [D2.7, Annex B].


### PR DESCRIPTION
I did some other proposals as well, see commit. The alphabethical sorting makes it look as if a lot of changes were done...

For the bijection entries: I tried to remove the duplication in the definitions. Instead, bijective model transformation and bijective data transformation are both defined as "bijective transformation where ..."

Before: 

> **Bijective Transformation**
> 
> In mathematics, a bijection, bijective function, or one-to-one correspondence is a function between the elements of two sets where each element of one set is paired with exactly one element of the other set, and each element of the other set is  paired with exactly one element of the first set. There are no unpaired elements. In terms of a transformation, this means that for every source model element, there is a corresponding element in the target model, and the transformation can first be executed in the direction `A > B` and then back `B > A'`, with `A` equal to `A'`.
> 
> [Wikipedia]
> 
> **Bijective Model Transformation**
> 
> A Bijective Model Transformation is a model transformation where each model element in the source and target model is paired with exactly one element of the other set, and each element of the other set is  paired with exactly one element of the first set. This means if the model transformation between an original model and the transsformed model is lossless, and the original model can be fully recreated based on the transformed model.
> 
> **Bijective Data Transformation**
> 
> This means if the data transformation between the default encoding and the alternative encoding is bijective, that conversion is lossless, and the original data set using the default encoding can be fully recreated based on the data that was transformed to the Alternative Encoding before.

After:

> **bijective data transformation**
> 
> bijective transformation where the two sets are data structures, consisting of data elements
> 
> NOTE 1 A transformed data structure can be transformed back again into the original data structure if the applied data transformation is bijective.
> 
> **bijective model transformation**
> 
> bijective transformation where the two sets are models, consisting of model elements
> 
> NOTE 1 The first data model is also called the source model and the second data model is also called the target model.
> 
> NOTE 2 A transformed model can be transformed back again into the original model if the applied model transformation is bijective.
> 
> **bijective transformation**<br />
> bijective function<br />
> bijection
> 
> function between the elements of two sets where each element of one set is paired with exactly one element of the other set, and each element of the other set is paired with exactly one element of the first set.
> 
> NOTE As a consequence, there are no unpaired elements in the two sets.
> 
> [Based on Wikipedia]